### PR TITLE
fix 修复flutter2.5版本下无法编译问题

### DIFF
--- a/ios/ali_auth.podspec
+++ b/ios/ali_auth.podspec
@@ -30,5 +30,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '9.0'
   # s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = {'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'   }
+  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end
 


### PR DESCRIPTION
flutter2.5 有一项升级是为支持了M1，提高了模拟器测试性能。所以打包的时候加入了 模拟器的arm64的arch。 详情看这里：https://github.com/flutter/flutter/pull/85642
但是阿里的ATAuthSDK是不支持的，所以打包的时候需要处理一下。
resolve #27 