### PR TITLE
修复IOS端因预取号无回调问题

### DIFF
--- a/ios/Classes/AliAuthPlugin.m
+++ b/ios/Classes/AliAuthPlugin.m
@@ -172,6 +172,8 @@ bool bool_false = false;
               if (![dic boolValueForKey: @"isDelay" defaultValue: NO]) {
                 [self loginWithModel: self->_model complete:^{}];
               }
+            }else{
+                [self showResult: resultDic];
             }
           }];
         } else {


### PR DESCRIPTION
在IOS端下.预取号失败时无返回值，无回调，init函数卡死（code：600012）