### PR TITLE
fix: iOS26 强制迁移 UIScene 下 VC 查找导致的异常

### DIFF
--- a/ios/Classes/AliAuthPlugin.m
+++ b/ios/Classes/AliAuthPlugin.m
@@ -655,6 +655,23 @@ bool bool_false = false;
 #pragma mark  ======在view上添加UIViewController========
 - (UIViewController *)findCurrentViewController{
     UIWindow *window = [[UIApplication sharedApplication].delegate window];
+
+     // 如果未获取到 window 且系统为 iOS 13+，尝试使用 connectedScenes
+    if (!window && @available(iOS 13.0, *)) {
+        NSSet<UIScene *> *scenes = [UIApplication sharedApplication].connectedScenes;
+        for (UIScene *scene in scenes) {
+            if ([scene isKindOfClass:[UIWindowScene class]] && scene.activationState == UISceneActivationStateForegroundActive) {
+                UIWindowScene *windowScene = (UIWindowScene *)scene;
+                for (UIWindow *w in windowScene.windows) {
+                    if (w.isKeyWindow) {
+                        window = w;
+                        break;
+                    }
+                }
+                if (window) break;
+            }
+        }
+    }
   
 //    UIViewController * vc = [[ViewController alloc] init];
 //    window.rootViewController = vc;


### PR DESCRIPTION
在今年的 WWDC25 上，Apple 发布 [TN3187](https://developer.apple.com/documentation/technotes/tn3187-migrating-to-the-uikit-scene-based-life-cycle) 文档，其中明确了要求：”在 iOS 26 之后的版本，任何使用最新 SDK 构建的 UIKit 应用都必须使用 UIScene 生命周期，否则将无法启动” 

Flutter 使用 flutter config --enable-uiscene-migration 迁移

迁移后会弹出新页面时会返回 flutter: AliAuth事件: code=600002, msg=唤起授权⻚失败！建议切换到其他登录⽅式
实际是因为 findCurrentViewController 返回了 nil 导致。